### PR TITLE
Add zod validation for trades

### DIFF
--- a/lib/database/trades.ts
+++ b/lib/database/trades.ts
@@ -2,25 +2,16 @@
 import { prisma } from "@/lib/prisma";
 import { TradeType, TradeStatus } from "@prisma/client";
 import { processInventoryMovement } from "@/lib/database/inventory";
+import {
+  tradeCreateSchema,
+  tradeUpdateSchema,
+  type TradeCreateInput,
+  type TradeUpdateInput,
+} from "@/lib/validation/trades";
 
-export interface CreateTradeData {
-  commodityId: string;
-  type: TradeType;
-  quantity: number;
-  price: number;
-  counterpartyId: string;
-  settlementDate: Date;
-  location: string;
-  userId?: string;
-}
+export type CreateTradeData = TradeCreateInput;
 
-export interface UpdateTradeData {
-  quantity?: number;
-  price?: number;
-  status?: TradeStatus;
-  settlementDate?: Date;
-  location?: string;
-}
+export type UpdateTradeData = TradeUpdateInput;
 
 export interface ExecuteTradeOptions {
   id: string;
@@ -30,8 +21,9 @@ export interface ExecuteTradeOptions {
 }
 
 // Create a new trade
-export async function createTrade(data: CreateTradeData) {
+export async function createTrade(input: CreateTradeData) {
   try {
+    const data = tradeCreateSchema.parse(input);
     // Validate commodity exists
     const commodity = await prisma.commodity.findUnique({
       where: { id: data.commodityId },
@@ -64,7 +56,14 @@ export async function createTrade(data: CreateTradeData) {
       // Create the trade
       const newTrade = await tx.trade.create({
         data: {
-          ...data,
+          commodityId: data.commodityId,
+          type: data.type,
+          quantity: data.quantity,
+          price: data.price,
+          counterpartyId: data.counterpartyId,
+          settlementDate: data.settlementDate,
+          location: data.location,
+          ...(data.userId ? { userId: data.userId } : {}),
           totalValue,
           status: TradeStatus.OPEN,
           // counterparty: { connect: { id: data.counterpartyId } },
@@ -172,8 +171,9 @@ export async function getTradeById(id: string) {
 }
 
 // Update trade
-export async function updateTrade(id: string, data: UpdateTradeData) {
+export async function updateTrade(id: string, input: UpdateTradeData) {
   try {
+    const data = tradeUpdateSchema.parse(input);
     return await prisma.$transaction(async (tx) => {
       const existingTrade = await tx.trade.findUnique({
         where: { id },
@@ -218,10 +218,28 @@ export async function updateTrade(id: string, data: UpdateTradeData) {
         );
       }
 
+      const sanitizedUpdateData: UpdateTradeData = {};
+
+      if (data.quantity !== undefined) {
+        sanitizedUpdateData.quantity = data.quantity;
+      }
+      if (data.price !== undefined) {
+        sanitizedUpdateData.price = data.price;
+      }
+      if (data.status !== undefined) {
+        sanitizedUpdateData.status = data.status;
+      }
+      if (data.settlementDate !== undefined) {
+        sanitizedUpdateData.settlementDate = data.settlementDate;
+      }
+      if (data.location !== undefined) {
+        sanitizedUpdateData.location = data.location;
+      }
+
       const updatedTrade = await tx.trade.update({
         where: { id },
         data: {
-          ...data,
+          ...sanitizedUpdateData,
           totalValue: recalculatedTotalValue,
           updatedAt: new Date(),
         },

--- a/lib/validation/trades.ts
+++ b/lib/validation/trades.ts
@@ -1,0 +1,56 @@
+import { TradeStatus, TradeType } from "@prisma/client";
+import { z } from "zod";
+
+const positiveQuantitySchema = z
+  .number()
+  .finite("Quantity must be a finite number")
+  .gt(0, "Quantity must be greater than zero");
+
+const positivePriceSchema = z
+  .number()
+  .finite("Price must be a finite number")
+  .gt(0, "Price must be greater than zero");
+
+const settlementDateSchema = z
+  .preprocess((value) => {
+    if (typeof value === "string" || value instanceof Date) {
+      const date = new Date(value);
+      if (!Number.isNaN(date.getTime())) {
+        return date;
+      }
+    }
+
+    return value;
+  }, z.date())
+  .refine((date) => !Number.isNaN(date.getTime()), {
+    message: "Settlement date must be a valid date",
+  });
+
+export const tradeCreateSchema = z.object({
+  commodityId: z.string().min(1, "Commodity is required"),
+  type: z.nativeEnum(TradeType),
+  quantity: positiveQuantitySchema,
+  price: positivePriceSchema,
+  counterpartyId: z.string().min(1, "Counterparty is required"),
+  settlementDate: settlementDateSchema,
+  location: z.string().min(1, "Location is required"),
+  userId: z.string().min(1).optional(),
+});
+
+export const tradeUpdateSchema = z
+  .object({
+    quantity: positiveQuantitySchema.optional(),
+    price: positivePriceSchema.optional(),
+    status: z.nativeEnum(TradeStatus).optional(),
+    settlementDate: settlementDateSchema.optional(),
+    location: z.string().min(1, "Location is required").optional(),
+  })
+  .refine(
+    (values) => Object.values(values).some((value) => value !== undefined),
+    {
+      message: "At least one field must be provided to update a trade",
+    },
+  );
+
+export type TradeCreateInput = z.infer<typeof tradeCreateSchema>;
+export type TradeUpdateInput = z.infer<typeof tradeUpdateSchema>;


### PR DESCRIPTION
## Summary
- add dedicated trade create/update schemas in `lib/validation/trades.ts`
- parse and sanitize trade payloads in the Prisma layer before executing database logic

## Testing
- pnpm lint
- pnpm type-check *(fails: existing references to `commodityPriceTick` models are missing from the Prisma client)*

------
https://chatgpt.com/codex/tasks/task_e_68d482818904832ba42467288e3263c0