### PR TITLE
trades: tighten update mutation typing

### DIFF
--- a/lib/hooks/use-trades.ts
+++ b/lib/hooks/use-trades.ts
@@ -8,6 +8,7 @@ import {
   cancelTrade,
   getTradeStatistics,
   getTradeById,
+  type UpdateTradeData,
 } from "@/lib/database/trades";
 import { TradeStatus, TradeType } from "@prisma/client";
 import { useToast } from "@/hooks/use-toast";
@@ -121,9 +122,12 @@ export function useUpdateTrade() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
-  return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: any }) =>
-      updateTrade(id, data),
+  return useMutation<
+    Awaited<ReturnType<typeof updateTrade>>,
+    Error,
+    { id: string; data: UpdateTradeData }
+  >({
+    mutationFn: ({ id, data }) => updateTrade(id, data),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ["trades"] });
       queryClient.invalidateQueries({ queryKey: ["trade", variables.id] });


### PR DESCRIPTION
## Summary
- import the UpdateTradeData type into the trades hook
- restrict the update mutation variables to enforce valid payload shapes

## Testing
- pnpm type-check *(fails: existing commodityPriceTick references are missing on the Prisma client)*

------
https://chatgpt.com/codex/tasks/task_e_68d482880d74832bbef04f48b24d191d