### PR TITLE
Fix inventory filter reset handling

### DIFF
--- a/app/counterparties/page.tsx
+++ b/app/counterparties/page.tsx
@@ -38,6 +38,7 @@ import {
 import type { CounterpartyTableRow } from "@/components/counterparties/counterparty-table";
 import { CounterpartyType, CreditRating } from "@prisma/client";
 import { useToast } from "@/hooks/use-toast";
+import { ALL_SELECT_VALUE, normalizeSelectValue } from "@/lib/utils";
 
 const pageSize = 10;
 
@@ -55,8 +56,12 @@ function useDebouncedValue<T>(value: T, delay: number) {
 export default function CounterpartiesPage() {
   const router = useRouter();
   const [searchTerm, setSearchTerm] = useState("");
-  const [typeFilter, setTypeFilter] = useState<"all" | CounterpartyType>("all");
-  const [ratingFilter, setRatingFilter] = useState<"all" | CreditRating>("all");
+  const [typeFilter, setTypeFilter] = useState<
+    CounterpartyType | typeof ALL_SELECT_VALUE
+  >(ALL_SELECT_VALUE);
+  const [ratingFilter, setRatingFilter] = useState<
+    CreditRating | typeof ALL_SELECT_VALUE
+  >(ALL_SELECT_VALUE);
   const [page, setPage] = useState(0);
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -73,6 +78,11 @@ export default function CounterpartiesPage() {
   const debouncedSearch = useDebouncedValue(searchTerm, 300);
   const { toast } = useToast();
 
+  const normalizedTypeFilter =
+    normalizeSelectValue<CounterpartyType>(typeFilter);
+  const normalizedRatingFilter =
+    normalizeSelectValue<CreditRating>(ratingFilter);
+
   const {
     data: counterparties = [],
     isLoading,
@@ -80,8 +90,8 @@ export default function CounterpartiesPage() {
     refetch,
     error,
   } = useCounterparties({
-    type: typeFilter === "all" ? undefined : typeFilter,
-    rating: ratingFilter === "all" ? undefined : ratingFilter,
+    type: normalizedTypeFilter,
+    rating: normalizedRatingFilter,
     searchTerm: debouncedSearch ? debouncedSearch : undefined,
     limit: pageSize,
     offset: page * pageSize,
@@ -327,7 +337,9 @@ export default function CounterpartiesPage() {
                 <Select
                   value={typeFilter}
                   onValueChange={(value) =>
-                    setTypeFilter(value as "all" | CounterpartyType)
+                    setTypeFilter(
+                      value as CounterpartyType | typeof ALL_SELECT_VALUE,
+                    )
                   }
                   disabled={isLoading && !counterparties.length}
                 >
@@ -335,7 +347,7 @@ export default function CounterpartiesPage() {
                     <SelectValue placeholder="Type" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">All Types</SelectItem>
+                    <SelectItem value={ALL_SELECT_VALUE}>All Types</SelectItem>
                     <SelectItem value={CounterpartyType.SUPPLIER}>
                       Supplier
                     </SelectItem>
@@ -348,7 +360,9 @@ export default function CounterpartiesPage() {
                 <Select
                   value={ratingFilter}
                   onValueChange={(value) =>
-                    setRatingFilter(value as "all" | CreditRating)
+                    setRatingFilter(
+                      value as CreditRating | typeof ALL_SELECT_VALUE,
+                    )
                   }
                   disabled={isLoading && !counterparties.length}
                 >
@@ -356,7 +370,9 @@ export default function CounterpartiesPage() {
                     <SelectValue placeholder="Rating" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">All Ratings</SelectItem>
+                    <SelectItem value={ALL_SELECT_VALUE}>
+                      All Ratings
+                    </SelectItem>
                     <SelectItem value={CreditRating.AAA}>AAA</SelectItem>
                     <SelectItem value={CreditRating.AA}>AA</SelectItem>
                     <SelectItem value={CreditRating.A}>A</SelectItem>

--- a/app/inventory/page.tsx
+++ b/app/inventory/page.tsx
@@ -40,18 +40,15 @@ import {
   useLowStockAlerts,
 } from "@/lib/hooks/use-inventory";
 import { useToast } from "@/hooks/use-toast";
-import { cn } from "@/lib/utils";
+import {
+  cn,
+  ALL_SELECT_VALUE,
+  getAllSelectValue,
+  normalizeSelectValue,
+} from "@/lib/utils";
 import type { Commodity, InventoryItem } from "@prisma/client";
 
 const SAVED_VIEWS_STORAGE_KEY = "inventory-saved-views";
-const ALL_FILTER_VALUE = "__all__";
-
-const shouldResetFilter = (value: string) => {
-  if (!value) return true;
-  if (value === ALL_FILTER_VALUE) return true;
-  return value.toLowerCase() === "all";
-};
-
 type InventoryFilters = {
   commodityId?: string;
   warehouse?: string;
@@ -67,23 +64,23 @@ type SavedView = {
 const sanitizeFilters = (filters: InventoryFilters): InventoryFilters => {
   const sanitized: InventoryFilters = {};
 
-  if (filters.commodityId && !shouldResetFilter(filters.commodityId)) {
-    sanitized.commodityId = filters.commodityId;
+  const commodityId = normalizeSelectValue<string>(filters.commodityId);
+  if (commodityId) {
+    sanitized.commodityId = commodityId;
   }
 
-  if (filters.warehouse && !shouldResetFilter(filters.warehouse)) {
-    sanitized.warehouse = filters.warehouse;
+  const warehouse = normalizeSelectValue<string>(filters.warehouse);
+  if (warehouse) {
+    sanitized.warehouse = warehouse;
   }
 
-  if (filters.location && !shouldResetFilter(filters.location)) {
-    sanitized.location = filters.location;
+  const location = normalizeSelectValue<string>(filters.location);
+  if (location) {
+    sanitized.location = location;
   }
 
   return sanitized;
 };
-
-const getFilterSelectValue = (value?: string) =>
-  value && !shouldResetFilter(value) ? value : ALL_FILTER_VALUE;
 
 type InventoryWithCommodity = InventoryItem & { commodity: Commodity };
 
@@ -500,11 +497,11 @@ export default function InventoryPage() {
             <div className="flex flex-col gap-3 md:flex-row md:items-end">
               <div className="flex flex-col gap-2 md:flex-row md:items-center">
                 <Select
-                  value={getFilterSelectValue(filters.commodityId)}
+                  value={getAllSelectValue(filters.commodityId)}
                   onValueChange={(value) =>
                     setFilters((current) => ({
                       ...current,
-                      commodityId: shouldResetFilter(value) ? undefined : value,
+                      commodityId: normalizeSelectValue<string>(value),
                     }))
                   }
                 >
@@ -512,7 +509,7 @@ export default function InventoryPage() {
                     <SelectValue placeholder="Commodity" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value={ALL_FILTER_VALUE}>
+                    <SelectItem value={ALL_SELECT_VALUE}>
                       All commodities
                     </SelectItem>
                     {commodityOptions.map((option) => (
@@ -523,11 +520,11 @@ export default function InventoryPage() {
                   </SelectContent>
                 </Select>
                 <Select
-                  value={getFilterSelectValue(filters.warehouse)}
+                  value={getAllSelectValue(filters.warehouse)}
                   onValueChange={(value) =>
                     setFilters((current) => ({
                       ...current,
-                      warehouse: shouldResetFilter(value) ? undefined : value,
+                      warehouse: normalizeSelectValue<string>(value),
                     }))
                   }
                 >
@@ -535,7 +532,7 @@ export default function InventoryPage() {
                     <SelectValue placeholder="Warehouse" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value={ALL_FILTER_VALUE}>
+                    <SelectItem value={ALL_SELECT_VALUE}>
                       All warehouses
                     </SelectItem>
                     {warehouses.map((warehouse) => (
@@ -546,11 +543,11 @@ export default function InventoryPage() {
                   </SelectContent>
                 </Select>
                 <Select
-                  value={getFilterSelectValue(filters.location)}
+                  value={getAllSelectValue(filters.location)}
                   onValueChange={(value) =>
                     setFilters((current) => ({
                       ...current,
-                      location: shouldResetFilter(value) ? undefined : value,
+                      location: normalizeSelectValue<string>(value),
                     }))
                   }
                 >
@@ -558,7 +555,7 @@ export default function InventoryPage() {
                     <SelectValue placeholder="Location" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value={ALL_FILTER_VALUE}>
+                    <SelectItem value={ALL_SELECT_VALUE}>
                       All locations
                     </SelectItem>
                     {locations.map((location) => (

--- a/app/trading/page.tsx
+++ b/app/trading/page.tsx
@@ -29,6 +29,7 @@ import { TradeStatus, TradeType } from "@prisma/client";
 import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
 import { useCommodities } from "@/lib/hooks/use-commodities";
+import { ALL_SELECT_VALUE, normalizeSelectValue } from "@/lib/utils";
 
 export default function TradingPage() {
   return (
@@ -44,8 +45,12 @@ export default function TradingPage() {
 
 function TradingPageContent() {
   const [searchTerm, setSearchTerm] = useState("");
-  const [statusFilter, setStatusFilter] = useState<string>("all");
-  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [statusFilter, setStatusFilter] = useState<
+    TradeStatus | typeof ALL_SELECT_VALUE
+  >(ALL_SELECT_VALUE);
+  const [typeFilter, setTypeFilter] = useState<
+    TradeType | typeof ALL_SELECT_VALUE
+  >(ALL_SELECT_VALUE);
   const searchParams = useSearchParams();
   const router = useRouter();
   const commodityIdFilter = searchParams.get("commodityId") ?? undefined;
@@ -53,14 +58,18 @@ function TradingPageContent() {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const { data: commodities = [] } = useCommodities();
 
+  const normalizedStatusFilter =
+    normalizeSelectValue<TradeStatus>(statusFilter);
+  const normalizedTypeFilter = normalizeSelectValue<TradeType>(typeFilter);
+
   const {
     data: trades = [],
     isLoading,
     error,
     refetch,
   } = useTrades({
-    status: statusFilter !== "all" ? (statusFilter as TradeStatus) : undefined,
-    type: typeFilter !== "all" ? (typeFilter as TradeType) : undefined,
+    status: normalizedStatusFilter,
+    type: normalizedTypeFilter,
     commodityId: commodityIdFilter,
   });
 
@@ -257,24 +266,36 @@ function TradingPageContent() {
                   className="pl-10 w-full sm:w-64"
                 />
               </div>
-              <Select value={statusFilter} onValueChange={setStatusFilter}>
+              <Select
+                value={statusFilter}
+                onValueChange={(value) =>
+                  setStatusFilter(
+                    value as TradeStatus | typeof ALL_SELECT_VALUE,
+                  )
+                }
+              >
                 <SelectTrigger className="w-full sm:w-32">
                   <SelectValue placeholder="Status" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="all">All Status</SelectItem>
+                  <SelectItem value={ALL_SELECT_VALUE}>All Status</SelectItem>
                   <SelectItem value="OPEN">Open</SelectItem>
                   <SelectItem value="EXECUTED">Executed</SelectItem>
                   <SelectItem value="SETTLED">Settled</SelectItem>
                   <SelectItem value="CANCELLED">Cancelled</SelectItem>
                 </SelectContent>
               </Select>
-              <Select value={typeFilter} onValueChange={setTypeFilter}>
+              <Select
+                value={typeFilter}
+                onValueChange={(value) =>
+                  setTypeFilter(value as TradeType | typeof ALL_SELECT_VALUE)
+                }
+              >
                 <SelectTrigger className="w-full sm:w-32">
                   <SelectValue placeholder="Type" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="all">All Types</SelectItem>
+                  <SelectItem value={ALL_SELECT_VALUE}>All Types</SelectItem>
                   <SelectItem value="BUY">Buy</SelectItem>
                   <SelectItem value="SELL">Sell</SelectItem>
                 </SelectContent>
@@ -344,8 +365,8 @@ function TradingPageContent() {
                             size="sm"
                             onClick={() => {
                               setSearchTerm("");
-                              setStatusFilter("all");
-                              setTypeFilter("all");
+                              setStatusFilter(ALL_SELECT_VALUE);
+                              setTypeFilter(ALL_SELECT_VALUE);
                               if (commodityIdFilter) {
                                 router.push("/trading");
                               }
@@ -422,8 +443,8 @@ function TradingPageContent() {
                     size="sm"
                     onClick={() => {
                       setSearchTerm("");
-                      setStatusFilter("all");
-                      setTypeFilter("all");
+                      setStatusFilter(ALL_SELECT_VALUE);
+                      setTypeFilter(ALL_SELECT_VALUE);
                       if (commodityIdFilter) {
                         router.push("/trading");
                       }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,37 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const ALL_SELECT_VALUE = "__all__";
+
+const normalizeCandidate = (value: string) => value.trim().toLowerCase();
+
+export function normalizeSelectValue<T extends string>(
+  value: T | typeof ALL_SELECT_VALUE | null | undefined,
+): T | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (value === ALL_SELECT_VALUE) {
+    return undefined;
+  }
+
+  const normalized = normalizeCandidate(value);
+
+  if (normalized.length === 0 || normalized === "all") {
+    return undefined;
+  }
+
+  return value as T;
+}
+
+export function getAllSelectValue(value?: string | null) {
+  const normalized = normalizeSelectValue<string>(value ?? undefined);
+
+  if (!normalized) {
+    return ALL_SELECT_VALUE;
+  }
+
+  return normalized;
+}


### PR DESCRIPTION
## Summary
- sanitize stored inventory filters so legacy "all" placeholder values no longer affect queries
- introduce a dedicated sentinel for "all" options and map select changes back to cleared filters
- keep saved views, normalized filters, and UI values consistent when the reset option is chosen

## Testing
- pnpm format
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68db080fed88832b838ac9fef23b3169